### PR TITLE
Some fixes to facilitate using recent MSYS2

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -43,7 +43,7 @@ build() {
     --enable-static \
     --enable-shared \
     --enable-introspection \
-    --with-included-loaders
+    --with-included-loaders=ani,icns,pcx,ras,tga,png,pnm,wbmp,xpm,qtif
   make
 }
 

--- a/mingw-w64-gtk2/0014-fix-broken-geninclude_pl_in-gtkdemo.patch
+++ b/mingw-w64-gtk2/0014-fix-broken-geninclude_pl_in-gtkdemo.patch
@@ -1,0 +1,47 @@
+--- gtk+-2.24.25/demos/gtk-demo/geninclude.pl.in.orig	2015-08-15 19:28:36.866853900 +0100
++++ gtk+-2.24.25/demos/gtk-demo/geninclude.pl.in	2015-08-15 19:29:24.468524500 +0100
+@@ -40,7 +40,7 @@
+ 	my $do_next = 0;
+ 
+ 	# parent detected
+-	if (defined @parents) {
++	if (@parents) {
+ 	    foreach $foo (@parents) {
+ 		if ($foo eq $parent_name) {
+ 		    $do_next = 1;
+@@ -54,7 +54,7 @@
+ 
+ 	push @parents, $parent_name;
+ 
+-	$tmp = (defined @child_arrays)?($#child_arrays + 1):0;
++	$tmp = (@child_arrays)?($#child_arrays + 1):0;
+ 	push @child_arrays, "child$tmp";
+ 
+ 	push @demos, {"title" => $parent_name, "file" => "NULL",
+@@ -62,7 +62,7 @@
+     }
+ }
+ 
+-if (defined @parents) {
++if (@parents) {
+     $i = 0;
+     for ($i = 0; $i <= $#parents; $i++) {
+ 	$first = 1;
+@@ -105,7 +105,7 @@
+ } @demos_old;
+ 
+ # sort the child arrays
+-if (defined @child_arrays) {
++if (@child_arrays) {
+     for ($i = 0; $i <= $#child_arrays; $i++) {
+ 	@foo_old = @{$child_arrays[$i]};
+ 
+@@ -133,7 +133,7 @@
+ 	print ", \n";
+     }
+ 
+-    if (defined @parents) {
++    if (@parents) {
+ 	for ($i = 0; $i <= $#parents; $i++) {
+ 	    if ($parents[$i] eq $href->{title}) {
+ 

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -39,7 +39,8 @@ source=("http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}
         0010-put-gtk-dll-into-path.mingw.patch
         0011-gir-for-gdkwin32.mingw.patch
         0012-embed-manifest.all.patch
-        0013-gtk-revert-recreatecairosurface-commit.patch)
+        0013-gtk-revert-recreatecairosurface-commit.patch
+        0014-fix-broken-geninclude_pl_in-gtkdemo.patch)
 
 md5sums=('612350704dd3aacb95355a4981930c6f'
          '5105b21ea13dbfbef8975138b4355e7a'
@@ -52,7 +53,8 @@ md5sums=('612350704dd3aacb95355a4981930c6f'
          '9e0296da2986be7697cf343563b85d1f'
          '91d12fc6da9026deb0f94f38ab22a3ec'
          '864a719c5fea860ced90cacab5545b1d'
-         '1dbf362025860675ace96bdfaa96f283')
+         '1dbf362025860675ace96bdfaa96f283'
+         'C1373B57CD3612120EEEFC9879BC6CFB')
 
 prepare() {
   cd gtk+-$pkgver
@@ -66,7 +68,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0011-gir-for-gdkwin32.mingw.patch
   #patch -p1 -i ${srcdir}/0012-embed-manifest.all.patch
   patch -p1 -i ${srcdir}/0013-gtk-revert-recreatecairosurface-commit.patch
-
+  patch -p1 -i ${srcdir}/0014-fix-broken-geninclude_pl_in-gtkdemo.patch
   autoreconf -fi
 }
 


### PR DESCRIPTION
Added a patch to GTK2 to make it compatible with recent perl versions

Disabled XBM as a format for pixbuf2 as it wasn't building
